### PR TITLE
Refactor React Hooks

### DIFF
--- a/examples/react/getting-started/src/pages/category.tsx
+++ b/examples/react/getting-started/src/pages/category.tsx
@@ -9,10 +9,10 @@ type CategoryParams = {
 
 export default function Category() {
   const { categorySlug } = useParams<CategoryParams>();
-  const { usePosts, useIsLoading } = client;
+  const { useQuery, useIsLoading } = client;
   const isLoading = useIsLoading();
 
-  const posts = usePosts({
+  const posts = useQuery().posts({
     where: {
       categoryName: categorySlug,
     },

--- a/examples/react/getting-started/src/pages/page.tsx
+++ b/examples/react/getting-started/src/pages/page.tsx
@@ -8,9 +8,9 @@ type PageParams = {
 
 export default function Page() {
   const { pageSlug } = useParams<PageParams>();
-  const { usePage, useIsLoading } = client;
+  const { useQuery, useIsLoading } = client;
   const isLoading = useIsLoading();
-  const page = usePage({
+  const page = useQuery().page({
     id: pageSlug,
     idType: PageIdType.URI,
   });

--- a/examples/react/getting-started/src/pages/post.tsx
+++ b/examples/react/getting-started/src/pages/post.tsx
@@ -8,10 +8,10 @@ type PostParams = {
 
 export default function Post() {
   const { postSlug } = useParams<PostParams>();
-  const { usePost, useIsLoading } = client;
+  const { useQuery, useIsLoading } = client;
   const isLoading = useIsLoading();
 
-  const post = usePost({
+  const post = useQuery().post({
     id: postSlug,
     idType: PostIdType.URI,
   });

--- a/examples/react/getting-started/src/pages/preview.tsx
+++ b/examples/react/getting-started/src/pages/preview.tsx
@@ -11,7 +11,7 @@ import queryString from 'query-string';
 import { useEffect } from 'react';
 
 export default function Preview() {
-  const { usePost, usePage, useIsLoading } = client;
+  const { useQuery, useIsLoading } = client;
   const isLoading = useIsLoading();
 
   useEffect(() => {
@@ -26,12 +26,12 @@ export default function Preview() {
 
   const { p, page_id, preview } = queryString.parse(window.location.search);
 
-  const page = usePage({
+  const page = useQuery().page({
     id: p as string,
     idType: PageIdType.DATABASE_ID,
   });
 
-  const post = usePost({
+  const post = useQuery().post({
     id: p as string,
     idType: PostIdType.DATABASE_ID,
   });

--- a/packages/next/src/client.ts
+++ b/packages/next/src/client.ts
@@ -66,8 +66,6 @@ export interface NextClient<
     args?: Parameters<Schema['query']['post']>[0],
   ): ReturnType<Schema['query']['post']>;
 
-  usePages: Schema['query']['pages'];
-
   usePage(
     args?: Parameters<Schema['query']['page']>[0],
   ): ReturnType<Schema['query']['page']>;
@@ -78,8 +76,6 @@ export interface NextClient<
   usePreview(
     args: Record<'postId', string>,
   ): ReturnType<Schema['query']['post']>;
-
-  useGeneralSettings(): Schema['query']['generalSettings'];
 
   useIsLoading(): boolean;
 }
@@ -207,10 +203,6 @@ export function getClient<
     >;
   }
 
-  const usePages: Schema['query']['pages'] = (args) => {
-    return useQuery().pages(args);
-  };
-
   function usePage(
     args?: Parameters<Schema['query']['page']>[0],
   ): ReturnType<Schema['query']['page']> {
@@ -337,11 +329,6 @@ export function getClient<
     ) as ReturnType<Schema['query']['category']>;
   }
 
-  const useGeneralSettings: () => Schema['query']['generalSettings'] = () => {
-    const client = useClient();
-    return client.useQuery().generalSettings;
-  };
-
   const useHydrateCache: typeof reactClient.useHydrateCache = ({
     cacheSnapshot,
     shouldRefetch,
@@ -383,10 +370,8 @@ export function getClient<
     useCategory,
     usePosts,
     usePost,
-    usePages,
     usePage,
     usePreview,
-    useGeneralSettings,
     useIsLoading,
   };
 

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -1,15 +1,15 @@
 import {
-  createReactClient,
-  CreateReactClientOptions,
-  ReactClient as GQlessReactClient,
-} from '@gqless/react';
-import {
   CategoryIdType,
   ClientConfig,
   getClient as getCoreClient,
   PageIdType,
   PostIdType,
 } from '@faustjs/core';
+import {
+  createReactClient,
+  CreateReactClientOptions,
+  ReactClient as GQlessReactClient,
+} from '@gqless/react';
 import { GQlessClient } from 'gqless';
 import isObject from 'lodash/isObject';
 import merge from 'lodash/merge';
@@ -47,29 +47,6 @@ export interface RequiredSchema {
 export interface ReactClient<Schema extends RequiredSchema>
   extends GQlessReactClient<Schema> {
   client: GQlessClient<Schema>;
-
-  useCategory(
-    args: Parameters<Schema['query']['category']>[0],
-  ): ReturnType<Schema['query']['category']>;
-
-  usePosts(
-    args: Parameters<Schema['query']['posts']>[0],
-  ): ReturnType<Schema['query']['posts']>;
-
-  usePost(
-    args: Parameters<Schema['query']['post']>[0],
-  ): ReturnType<Schema['query']['post']>;
-
-  usePages(
-    args: Parameters<Schema['query']['pages']>[0],
-  ): ReturnType<Schema['query']['pages']>;
-
-  usePage(
-    args: Parameters<Schema['query']['page']>[0],
-  ): ReturnType<Schema['query']['page']>;
-
-  useGeneralSettings(): Schema['query']['generalSettings'];
-
   useIsLoading(): boolean;
 }
 
@@ -109,149 +86,6 @@ export function getClient<
 
   const { useQuery } = reactClient;
 
-  /**
-   * React Hook for retrieving a list of posts from your WordPress site
-   *
-   * @example
-   * ```tsx
-   * import { usePosts } from '../client'
-   *
-   * export function ListPosts() {
-   *   const posts = usePosts();
-   *
-   *   if (!posts) {
-   *     return <></>;
-   *   }
-   *
-   *   return (
-   *     <>
-   *       {posts.map((post) => (
-   *         <div key={post?.id} dangerouslySetInnerHTML={ { __html: post?.content() ?? '' } } />
-   *       ))}
-   *     </>
-   *   );
-   * }
-   * }
-   * ```
-   */
-  const usePosts = (args: Parameters<Schema['query']['posts']>[0]) => {
-    return useQuery().posts(args) as ReturnType<Schema['query']['posts']>;
-  };
-
-  /**
-   * React Hook for retrieving the post based on the current URI. Uses window.location if necessary
-   *
-   * @example
-   * ```tsx
-   * import { usePost } from '../client';
-   *
-   * export default function Post() {
-   *   const post = usePost();
-   *
-   *   return (
-   *     <div>
-   *       {post && (
-   *         <div>
-   *           <div>
-   *             <h5>{post?.title}</h5>
-   *             <p dangerouslySetInnerHTML={{ __html: post?.content() ?? '' }} />
-   *           </div>
-   *         </div>
-   *       )}
-   *     </div>
-   *   );
-   * }
-   * ```
-   */
-  const usePost = (args: Parameters<Schema['query']['post']>[0]) => {
-    return useQuery().post(args) as ReturnType<Schema['query']['post']>;
-  };
-
-  /**
-   * React Hook for retrieving a list of posts from your WordPress site
-   *
-   * @example
-   * ```tsx
-   * import { usePages } from '../client'
-   *
-   * export function ListPages() {
-   *   const pages = usePages();
-   *
-   *   if (!pages) {
-   *     return <></>;
-   *   }
-   *
-   *   return (
-   *     <>
-   *       {pages.map((page) => (
-   *         <div key={page?.id} dangerouslySetInnerHTML={ { __html: page?.content() ?? '' } } />
-   *       ))}
-   *     </>
-   *   );
-   * }
-   * }
-   * ```
-   */
-  const usePages = (args: Parameters<Schema['query']['pages']>[0]) => {
-    return useQuery().pages(args) as ReturnType<Schema['query']['pages']>;
-  };
-
-  /**
-   * React Hook for retrieving the page based on the current URI. Uses window.location if necessary
-   *
-   * @example
-   * ```tsx
-   * import { usePage } from '../client';
-   *
-   * export default function Page() {
-   *   const page = usePage();
-   *
-   *   return (
-   *     <div>
-   *       {page && (
-   *         <div>
-   *           <div>
-   *             <h5>{page?.title}</h5>
-   *             <p dangerouslySetInnerHTML={{ __html: page?.content() ?? '' }} />
-   *           </div>
-   *         </div>
-   *       )}
-   *     </div>
-   *   );
-   * }
-   * ```
-   */
-  const usePage = (args: Parameters<Schema['query']['page']>[0]) => {
-    return useQuery().page(args) as ReturnType<Schema['query']['page']>;
-  };
-
-  const useCategory = (args: Parameters<Schema['query']['category']>[0]) => {
-    return useQuery().category(args) as ReturnType<Schema['query']['category']>;
-  };
-
-  /**
-   * React Hook for retrieving the general settings (title, description) form your WordPress site
-   *
-   * @example
-   * ```tsx
-   * import {useGeneralSettings} from '../client';
-   *
-   * export function Header() {
-   *  const settings = useGeneralSettings();
-   *
-   *  return(
-   *    <header>
-   *      <h1>{settings?.title}</h1>
-   *      <h2>{settings?.description}</h2>
-   *    </header>
-   *  )
-   * }
-   * ```
-   */
-  const useGeneralSettings: () => Schema['query']['generalSettings'] = () => {
-    return useQuery().generalSettings;
-  };
-
   const useIsLoading = () => {
     return useQuery().$state.isLoading;
   };
@@ -259,12 +93,6 @@ export function getClient<
   const c: ReactClient<Schema> = {
     client: coreClient,
     ...reactClient,
-    useCategory,
-    usePosts,
-    usePost,
-    usePages,
-    usePage,
-    useGeneralSettings,
     useIsLoading,
   };
 


### PR DESCRIPTION
This PR resolves #327.

Removed hooks from the `react` package that had a 1-to-1 representation of the GQless `useQuery` hook and refactored the `react/getting-started` example accordingly.

Additionally, the `useGeneralSettings` and `usePages` hooks were removed from the `next` client