### PR TITLE
Site development environment set

### DIFF
--- a/internal/website/docs/guides/custom-post-types.mdx
+++ b/internal/website/docs/guides/custom-post-types.mdx
@@ -86,7 +86,7 @@ Your schema is a TypeScript representation of your WordPress site. Since we have
 npm run generate
 ```
 
-[Learn more about generating your client/schema here.](/next/generating-client)
+[Learn more about generating your client/schema here.](/next/fetching-data)
 
 ### Run the dev server
 

--- a/internal/website/docs/next/getting-started.mdx
+++ b/internal/website/docs/next/getting-started.mdx
@@ -44,7 +44,7 @@ Currently, the posts and pages you see are coming from our WordPress site at [ht
 
 The example app above loads WordPress content from the demo site at [https://headlessfw.wpengine.com](https://headlessfw.wpengine.com).
 
-To point it to a different WordPress site, first, [make sure you have setup the necessary WordPress plugins.](/getting-started#prerequisites)
+To point it to a different WordPress site, first, [make sure you have setup the necessary WordPress plugins.](/getting-started/setting-up-wordpress)
 
 Once the necessary plugins have been installed, open the `.env.local` file you created earlier, it should look something like this:
 
@@ -69,5 +69,5 @@ WP_HEADLESS_SECRET=YOUR_PLUGIN_SECRET
 Update the `NEXT_PUBLIC_WORDPRESS_URL` value with your WordPress site URL (be sure to include `http://` or `https://`).
 
 Additionally, update the `WP_HEADLESS_SECRET` value with the secret key found in Settings → Headless in your WordPress admin area to support previews.
-    
+
 <img src="/docs/img/headless-admin-secret.png" alt="The Headless WordPress admin interface with a red rectangle around the Secret Key field" />

--- a/internal/website/docusaurus.config.js
+++ b/internal/website/docusaurus.config.js
@@ -45,7 +45,7 @@ module.exports = {
             },
             {
               label: 'Getting Started',
-              to: '/getting-started',
+              to: '/getting-started/setting-up-wordpress',
             },
             {
               label: 'Usage with Next.js',

--- a/internal/website/package.json
+++ b/internal/website/package.json
@@ -10,6 +10,7 @@
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
+    "serve:prod": "npm run serve -- --build --port 8080 --host 0.0.0.0",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },

--- a/internal/website/src/pages/index.js
+++ b/internal/website/src/pages/index.js
@@ -16,7 +16,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro">
+            to="/introduction">
             Docusaurus Tutorial - 5min ⏱️
           </Link>
         </div>

--- a/package.json
+++ b/package.json
@@ -27,10 +27,12 @@
     "test": "npm test --workspace=@faustjs/core --workspace=@faustjs/react --workspace=@faustjs/next",
     "minor": "npm version minor --git-tag-version=false --workspace=@faustjs/core --workspace=@faustjs/react --workspace=@faustjs/next",
     "patch": "npm version patch --git-tag-version=false --workspace=@faustjs/core --workspace=@faustjs/react --workspace=@faustjs/next",
+    "start": "npm run serve:prod --prefix internal/website",
     "wp-env": "wp-env",
     "wp:start": "wp-env start",
     "wp:stop": "wp-env stop",
-    "wp:destroy": "wp-env destroy"
+    "wp:destroy": "wp-env destroy",
+    "wpe-build": "npm run docs:build"
   },
   "devDependencies": {
     "@wordpress/env": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "wp:start": "wp-env start",
     "wp:stop": "wp-env stop",
     "wp:destroy": "wp-env destroy",
-    "wpe-build": "npm run docs:build"
+    "wpe-build": "cd internal/website && npm i && cd .. && npm run docs:build"
   },
   "devDependencies": {
     "@wordpress/env": "^4.0.0",


### PR DESCRIPTION
This site is deployed to Atlas into a "Development" environment. We'll keep this branch open for subsequent deployments. Once we're ready to go live we can set a branch for production deployments and map a domain.

resolves #332 