### PR TITLE
Remove duplicate field registers for templates and conditionalTags

### DIFF
--- a/plugins/wpe-headless/includes/graphql/callbacks.php
+++ b/plugins/wpe-headless/includes/graphql/callbacks.php
@@ -39,15 +39,6 @@ function wpe_headless_register_templates_field() {
 			'resolve' => 'wpe_headless_templates_resolver',
 		)
 	);
-
-	register_graphql_field(
-		'ContentNode',
-		'templates',
-		array(
-			'type'    => array( 'list_of' => 'String' ),
-			'resolve' => 'wpe_headless_templates_resolver',
-		)
-	);
 }
 
 /**
@@ -164,15 +155,6 @@ function wpe_headless_register_conditional_tags_field() {
 
 	register_graphql_field(
 		'UniformResourceIdentifiable',
-		'conditionalTags',
-		array(
-			'type'    => 'ConditionalTags',
-			'resolve' => 'wpe_headless_conditional_tags_resolver',
-		)
-	);
-
-	register_graphql_field(
-		'ContentNode',
 		'conditionalTags',
 		array(
 			'type'    => 'ConditionalTags',


### PR DESCRIPTION
In our wpgql field logic we are registering two of the same field identifier. This PR removes the one associated with ContentNode as templates seem more appropriate for the previous declaration which includes the context in which the post type or model is used. This also applies to `conditionalTags`

Having trouble running tests locally so hoping someone can give a second look that this change doesn't introduce new issues. I anticipate it wont considering most of the usage of these fields are on the app side. 

Steps to reproduce: 
1) Follow getting started guide for building an Atlas app
2) Create WP install fresh and install the required plugins + wpgql
3) See that the duplicate field error when you run a wpqgl query from IDE with debug mode on

Example error from wpgql IDE with debug mode turned on:
```        "type": "DUPLICATE_FIELD",
        "message": "You cannot register duplicate fields on the same Type. The field 'templates' already exists on the type 'ContentNode'. Make sure to give the field a unique name.",
        "field_name": "templates",
        "type_name": "ContentNode",```