### PR TITLE
Return templates object in the template_hierarchy callback

### DIFF
--- a/plugins/wpe-headless/includes/graphql/callbacks.php
+++ b/plugins/wpe-headless/includes/graphql/callbacks.php
@@ -117,6 +117,7 @@ function wpe_headless_templates_resolver( $root, $args, AppContext $context, Res
 function wpe_headless_log_template_hierarchy( $templates ) {
 	global $wpe_headless_checked_templates;
 	$wpe_headless_checked_templates = array_merge( $wpe_headless_checked_templates, $templates );
+	return $wpe_headless_checked_templates;
 }
 
 add_action( 'graphql_register_types', 'wpe_headless_register_conditional_tags_field' );

--- a/plugins/wpe-headless/includes/graphql/callbacks.php
+++ b/plugins/wpe-headless/includes/graphql/callbacks.php
@@ -112,7 +112,7 @@ function wpe_headless_templates_resolver( $root, $args, AppContext $context, Res
  *
  * @param string[] $templates Templates being loaded.
  *
- * @return void
+ * @return array
  */
 function wpe_headless_log_template_hierarchy( $templates ) {
 	global $wpe_headless_checked_templates;


### PR DESCRIPTION
In WordPress 5.8 the templates hierarchy filter used by full site editing is null because we are not returning the object in our callback. This PR properly returns the filtered object as WordPress expects fixing Headless Framework for WordPress 5.8 users.

