### PR TITLE
SSG Temporary Fix

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@faustjs/core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faustjs/core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "This module helps you use WordPress as a Headless CMS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faustjs/next",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "This module helps you use WordPress as a Headless CMS with Next.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/next/src/getProps.tsx
+++ b/packages/next/src/getProps.tsx
@@ -66,28 +66,22 @@ export async function getProps<
   client.setAsRoot();
 
   if (!isNil(Page)) {
-    const renderResult = await client.prepareReactRender(
-      React.createElement(
-        RouterContext.Provider,
-        {
-          value: {
-            query: {
-              ...context.params,
-              ...(context as GetServerSidePropsContext).query,
-            },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } as any,
-        },
-        React.createElement(
-          HeadlessContext.Provider,
-          {
-            value: {
-              client,
-            },
-          },
-          React.createElement(Page, props),
-        ),
-      ),
+    let renderResult = await client.prepareReactRender(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <RouterContext.Provider value={{ query: { ...context.params } } as any}>
+        <HeadlessContext.Provider value={{ client }}>
+          <Page {...props} />
+        </HeadlessContext.Provider>
+      </RouterContext.Provider>,
+    );
+
+    renderResult = await client.prepareReactRender(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <RouterContext.Provider value={{ query: { ...context.params } } as any}>
+        <HeadlessContext.Provider value={{ client }}>
+          <Page {...props} />
+        </HeadlessContext.Provider>
+      </RouterContext.Provider>,
     );
 
     cacheSnapshot = renderResult.cacheSnapshot;

--- a/packages/next/src/getProps.tsx
+++ b/packages/next/src/getProps.tsx
@@ -70,6 +70,7 @@ export async function getProps<
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       <RouterContext.Provider value={{ query: { ...context.params } } as any}>
         <HeadlessContext.Provider value={{ client }}>
+          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
           <Page {...props} />
         </HeadlessContext.Provider>
       </RouterContext.Provider>,
@@ -79,6 +80,7 @@ export async function getProps<
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       <RouterContext.Provider value={{ query: { ...context.params } } as any}>
         <HeadlessContext.Provider value={{ client }}>
+          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
           <Page {...props} />
         </HeadlessContext.Provider>
       </RouterContext.Provider>,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faustjs/react",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "This module helps you use WordPress as a Headless CMS with React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Based on #343 and some testing of my own, it appears there is a bug in gqless related to prerendering. A temporary fix is to simply prerender twice. This fix does exactly that. I've tested this and it appears to work with the `next/getting-started` as well as other sites.