### PR TITLE
make: (#365) Increment plugin versions to 0.5.6

### DIFF
--- a/plugins/wpe-headless/readme.txt
+++ b/plugins/wpe-headless/readme.txt
@@ -4,7 +4,7 @@ Tags:
 Requires at least: 5.3
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 0.5.5
+Stable tag: 0.5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Author: WP Engine
@@ -22,6 +22,11 @@ Transform your WordPress site to a powerful Headless API.
 == Screenshots ==
 
 == Changelog ==
+
+
+= 0.5.6 =
+
+- Fixes an issue where we were not properly returning the templates hierarchy from the templates hierarchy filter.
 
 = 0.5.5 =
 

--- a/plugins/wpe-headless/wpe-headless.php
+++ b/plugins/wpe-headless/wpe-headless.php
@@ -7,7 +7,7 @@
  * Author URI: https://wpengine.com/
  * Text Domain: wpe-headless
  * Domain Path: /languages
- * Version: 0.5.5
+ * Version: 0.5.6
  *
  * @package WPE_Headless
  */


### PR DESCRIPTION
This release includes a fix for properly returning the templates hierarchy from the templates hierarchy filter that causes the Headless Framework to crash.

This PR resolves #365