### PR TITLE
fix: setting proper dotenv config

### DIFF
--- a/examples/next/getting-started/gqless.config.js
+++ b/examples/next/getting-started/gqless.config.js
@@ -1,4 +1,6 @@
-require('dotenv').config();
+require('dotenv').config({
+  path: '.env.local',
+});
 require('./src/faust.config');
 const { getGqlUrl } = require('@faustjs/core');
 

--- a/examples/react/getting-started/gqless.config.js
+++ b/examples/react/getting-started/gqless.config.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 require('./src/faust.config');
 const { getGqlUrl } = require('@faustjs/core');
 


### PR DESCRIPTION
For the next getting started `require('dotenv').config();` is not enough because it defaults to `.env` for the file rather than `.env.local`. So we need an additional setting of:

```js
require('dotenv').config({
  path: '.env.local',
});
```